### PR TITLE
Bump OpenBSD to 6.9 and install full sets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
         matrix:
           version:
-            - 6.8
+            - 6.9
 
           architecture:
             - x86-64

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,10 @@
-# trigger
 # OpenBSD Builder
 
 This project builds the OpenBSD VM image for the
 [cross-platform-actions/action](https://github.com/cross-platform-actions/action)
-GitHub action. The image contains a standard OpenBSD installation without any
-X components, man pages or games. It will install the following file sets:
+GitHub action. The image contains a standard OpenBSD installation.
 
-* bsd
-* bsd.mp
-* bsd.rd
-* baseXX.tgz
-* compXX.tgz
-
-In addition to the above file sets, the following packages are installed as well:
+In addition to the OpenBSD file sets, the following packages are installed as well:
 
 * sudo
 * bash
@@ -30,6 +22,7 @@ The following architectures and versions are supported:
 | Version | x86-64 | arm64 |
 |---------|--------|-------|
 | 6.8     | ✓      | ✓     |
+| 6.9     | ✓      | ✓     |
 
 ## Building Locally
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+# trigger
 # OpenBSD Builder
 
 This project builds the OpenBSD VM image for the

--- a/resources/install.conf
+++ b/resources/install.conf
@@ -10,5 +10,5 @@ Which disk is the root disk = sd0
 Use (W)hole disk MBR, whole disk (G)PT or (E)dit = g
 URL to autopartitioning template for disklabel = {{ DISKLABEL_TEMPLATE }}
 Http Server = cdn.openbsd.org
-Set name(s) = -game* -x* -man*
+Set name(s) = 
 Directory does not contain SHA256.sig. Continue without verification = yes

--- a/var_files/6.9/arm64.pkrvars.hcl
+++ b/var_files/6.9/arm64.pkrvars.hcl
@@ -1,0 +1,1 @@
+checksum = "sha256:fed4a85aabb51f6dd7ff981ed2ab26e636eb18e409b26b87fab6a2a607ab1348"

--- a/var_files/6.9/common.pkrvars.hcl
+++ b/var_files/6.9/common.pkrvars.hcl
@@ -1,0 +1,3 @@
+os_version = "6.9"
+sudo_version = "1.9.6.1"
+rsync_version = "3.2.3p0"

--- a/var_files/6.9/x86-64.pkrvars.hcl
+++ b/var_files/6.9/x86-64.pkrvars.hcl
@@ -1,0 +1,1 @@
+checksum = "sha256:a85d98117f59ae7b9bdbbcce2067166c7cff0efc6593bc5cc1960e6a6f207c98"


### PR DESCRIPTION
Please see #1  for more info. 

P.S. https://github.com/cross-platform-actions/action has to be tweaked to use the new version.