### PR TITLE
Add support for OpenBSD 6.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         matrix:
           version:
             - 6.8
+            - 6.9
 
           architecture:
             - x86-64

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ The following architectures and versions are supported:
 | Version | x86-64 | arm64 |
 |---------|--------|-------|
 | 6.8     | ✓      | ✓     |
+| 6.9     | ✓      | ✓     |
 
 ## Building Locally
 

--- a/var_files/6.9/arm64.pkrvars.hcl
+++ b/var_files/6.9/arm64.pkrvars.hcl
@@ -1,0 +1,1 @@
+checksum = "sha256:fed4a85aabb51f6dd7ff981ed2ab26e636eb18e409b26b87fab6a2a607ab1348"

--- a/var_files/6.9/common.pkrvars.hcl
+++ b/var_files/6.9/common.pkrvars.hcl
@@ -1,0 +1,3 @@
+os_version = "6.9"
+sudo_version = "1.9.6.1"
+rsync_version = "3.2.3p0"

--- a/var_files/6.9/x86-64.pkrvars.hcl
+++ b/var_files/6.9/x86-64.pkrvars.hcl
@@ -1,0 +1,1 @@
+checksum = "sha256:a85d98117f59ae7b9bdbbcce2067166c7cff0efc6593bc5cc1960e6a6f207c98"


### PR DESCRIPTION
This PR add OpenBSD 6.9 to the list of supported system, also bumps some packages.
Both x86-64 and arm64 version seem to be usable,

Separated from #1 