### PR TITLE
Support snapshots

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,15 @@ set -euxo pipefail
 OS_VERSION="$1"; shift
 ARCHITECTURE="$1"; shift
 
-packer build \
-  -var os_version="$OS_VERSION" \
-  -var-file "var_files/common.pkrvars.hcl" \
-  -var-file "var_files/$ARCHITECTURE.pkrvars.hcl" \
-  -var-file "var_files/$OS_VERSION/$ARCHITECTURE.pkrvars.hcl" \
-  "$@" \
-  openbsd.pkr.hcl
+flags=(
+  "-var"      "os_version=$OS_VERSION"
+  "-var-file" "var_files/common.pkrvars.hcl"
+  "-var-file" "var_files/$ARCHITECTURE.pkrvars.hcl"
+)
+
+if [ -e "var_files/$OS_VERSION/$ARCHITECTURE.pkrvars.hcl" ]; then
+  flags+=("-var-file")
+  flags+=("var_files/$OS_VERSION/$ARCHITECTURE.pkrvars.hcl")
+fi
+
+packer build "${flags[@]}" "$@" openbsd.pkr.hcl

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,15 @@ install location to `resources/ovmf.fd`.
     Where `<version>` and `<architecture>` are the any of the versions or
     architectures available in the above table.
 
+    To target a snapshot, override the `checksum` variable manually by
+    specifying `-var checksum=<checksum>` at the end when invoking the `build.sh`
+    script. You can find the appropriate checksum by looking at the SHA256 file
+    for `miniroot<version>.img` on [an OpenBSD mirror](https://www.openbsd.org/ftp.html).
+
+    ```
+    ./build.sh <version> <architecture> -var checksum=<checksum>
+    ```
+
     On non-macOS platforms the `display` variable needs to be overridden by
     specifying `-var display=gtk` or `-var display=sdl` at the end when invoking
     the `build.sh` script:


### PR DESCRIPTION
I haven't used Packer or HCL before, but from what I can tell, it looks like this *should* work.

To install the latest snapshot:

```
./build.sh 7.6 x86-64 -var checksum=536fda4f519359eebd092900b7ee27986cccb800aee321b3b5d4841d7ce42cd2
```

closes #18 